### PR TITLE
fixes #21 i.e. no react application context found

### DIFF
--- a/android/src/main/java/com/reactlibrary/ThreadBaseReactPackage.java
+++ b/android/src/main/java/com/reactlibrary/ThreadBaseReactPackage.java
@@ -35,7 +35,7 @@ public class ThreadBaseReactPackage implements ReactPackage {
     public List<NativeModule> createNativeModules(ReactApplicationContext catalystApplicationContext) {
         return Arrays.<NativeModule>asList(
                 // Core list
-                new AndroidInfoModule(),
+                new AndroidInfoModule(catalystApplicationContext),
                 new ExceptionsManagerModule(reactInstanceManager.getDevSupportManager()),
                 new AppStateModule(catalystApplicationContext),
                 new Timing(catalystApplicationContext, reactInstanceManager.getDevSupportManager()),


### PR DESCRIPTION
Fixed the error `no react application context found` in AndroidInfoModule while building the module.
Working with RN: 0.55.2