### PR TITLE
replace addNativeModule call with processPackage call

### DIFF
--- a/android/src/main/java/com/reactlibrary/ReactContextBuilder.java
+++ b/android/src/main/java/com/reactlibrary/ReactContextBuilder.java
@@ -10,7 +10,6 @@ import com.facebook.react.bridge.CatalystInstanceImpl;
 import com.facebook.react.bridge.JSBundleLoader;
 import com.facebook.react.bridge.JSCJavaScriptExecutorFactory;
 import com.facebook.react.bridge.JavaScriptExecutor;
-import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.NativeModuleCallExceptionHandler;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.ReactInstanceManager;
@@ -70,7 +69,7 @@ public class ReactContextBuilder {
 
         // load native modules
         NativeModuleRegistryBuilder nativeRegistryBuilder = new NativeModuleRegistryBuilder(reactContext, this.instanceManager);
-        addNativeModules(reactContext, nativeRegistryBuilder);
+        addNativeModules(nativeRegistryBuilder);
 
         CatalystInstanceImpl.Builder catalystInstanceBuilder = new CatalystInstanceImpl.Builder()
                 .setReactQueueConfigurationSpec(ReactQueueConfigurationSpec.createDefault())
@@ -130,12 +129,10 @@ public class ReactContextBuilder {
         };
     }
 
-    private void addNativeModules(ReactApplicationContext reactContext, NativeModuleRegistryBuilder nativeRegistryBuilder) {
+    private void addNativeModules(NativeModuleRegistryBuilder nativeRegistryBuilder) {
         for (int i = 0; i < reactPackages.size(); i++) {
             ReactPackage reactPackage = reactPackages.get(i);
-            for (NativeModule nativeModule : reactPackage.createNativeModules(reactContext)) {
-                nativeRegistryBuilder.addNativeModule(nativeModule);
-            }
+            nativeRegistryBuilder.processPackage(reactPackage);
         }
     }
 }


### PR DESCRIPTION
Fix compilation errors with react-native 0.58

We still encounter a runtime error that will need to be addressed

```
Could not invoke ThreadManager.startThread
null
No implementation found for com.facebook.jni.HybridData
```