### PR TITLE
Replace deprecated `compile` configuration with `implementation` in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,6 +36,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }
 


### PR DESCRIPTION
As per https://developer.android.com/studio/build/dependencies#dependency_configurations