### PR TITLE
[Android] Support React Native v0.60

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,13 +11,16 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 23)
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 22)
         versionCode 1
         versionName "1.0"
     }

--- a/android/src/main/java/com/reactlibrary/ThreadBaseReactPackage.java
+++ b/android/src/main/java/com/reactlibrary/ThreadBaseReactPackage.java
@@ -10,7 +10,6 @@ import com.facebook.react.modules.core.ExceptionsManagerModule;
 import com.facebook.react.modules.core.Timing;
 import com.facebook.react.modules.debug.SourceCodeModule;
 import com.facebook.react.modules.intent.IntentModule;
-import com.facebook.react.modules.location.LocationModule;
 import com.facebook.react.modules.netinfo.NetInfoModule;
 import com.facebook.react.modules.network.NetworkingModule;
 import com.facebook.react.modules.storage.AsyncStorageModule;
@@ -46,7 +45,6 @@ public class ThreadBaseReactPackage implements ReactPackage {
                 // Main list
                 new AsyncStorageModule(catalystApplicationContext),
                 new IntentModule(catalystApplicationContext),
-                new LocationModule(catalystApplicationContext),
                 new NetworkingModule(catalystApplicationContext),
                 new NetInfoModule(catalystApplicationContext),
                 new VibrationModule(catalystApplicationContext),


### PR DESCRIPTION
- Remove `LocationModule` on Android, it's no longer live on RN >= 0.60
- Override versions with root project for support AndroidX
- Support use Hermes JS engine on react-native-threads (If not, it will get error of `jscexecutor.so` not found with `enableHermes: true`)