### PR TITLE
[iOS] Fix podspec for React Native v0.60 autolinking

### DIFF
--- a/ios/RNThread.podspec
+++ b/ios/RNThread.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = "https://github.com/joltup/RNThread.git"
   s.source       = { :git => "https://github.com/joltup/RNThread.git", :tag => s.version }
-  s.source_files  = "RNThread/**/*.{h,m}"
+  s.source_files  = "**/*.{h,m}"
+  s.platform      = :ios, "7.0"
 
   s.dependency 'React'
 end


### PR DESCRIPTION
- Fix podspec `source_files` field, make it right for React Native v0.60 autolinking